### PR TITLE
Added `labels` to package definition

### DIFF
--- a/pkg/package/database.go
+++ b/pkg/package/database.go
@@ -45,6 +45,9 @@ type PackageSet interface {
 	World() []Package
 
 	FindPackageCandidate(p Package) (Package, error)
+	FindPackageLabel(labelKey string) ([]Package, error)
+	FindPackageLabelMatch(pattern string) ([]Package, error)
+	FindPackageMatch(pattern string) ([]Package, error)
 }
 
 type PackageFile struct {

--- a/pkg/package/database_boltdb.go
+++ b/pkg/package/database_boltdb.go
@@ -18,6 +18,7 @@ package pkg
 import (
 	"encoding/base64"
 	"os"
+	"regexp"
 	"strconv"
 	"sync"
 	"time"
@@ -383,4 +384,62 @@ func (db *BoltDatabase) FindPackageVersions(p Package) ([]Package, error) {
 		versionsInWorld = append(versionsInWorld, w)
 	}
 	return versionsInWorld, nil
+}
+
+func (db *BoltDatabase) FindPackageLabel(labelKey string) ([]Package, error) {
+	var ans []Package
+
+	for _, k := range db.GetPackages() {
+		pack, err := db.GetPackage(k)
+		if err != nil {
+			return ans, err
+		}
+		if pack.HasLabel(labelKey) {
+			ans = append(ans, pack)
+		}
+	}
+	return ans, nil
+}
+
+func (db *BoltDatabase) FindPackageLabelMatch(pattern string) ([]Package, error) {
+	var ans []Package
+
+	re := regexp.MustCompile(pattern)
+	if re == nil {
+		return nil, errors.New("Invalid regex " + pattern + "!")
+	}
+
+	for _, k := range db.GetPackages() {
+		pack, err := db.GetPackage(k)
+		if err != nil {
+			return ans, err
+		}
+		if pack.MatchLabel(re) {
+			ans = append(ans, pack)
+		}
+	}
+
+	return ans, nil
+}
+
+func (db *BoltDatabase) FindPackageMatch(pattern string) ([]Package, error) {
+	var ans []Package
+
+	re := regexp.MustCompile(pattern)
+	if re == nil {
+		return nil, errors.New("Invalid regex " + pattern + "!")
+	}
+
+	for _, k := range db.GetPackages() {
+		pack, err := db.GetPackage(k)
+		if err != nil {
+			return ans, err
+		}
+
+		if re.MatchString(pack.GetCategory() + pack.GetName()) {
+			ans = append(ans, pack)
+		}
+	}
+
+	return ans, nil
 }

--- a/pkg/package/database_mem.go
+++ b/pkg/package/database_mem.go
@@ -18,6 +18,7 @@ package pkg
 import (
 	"encoding/base64"
 	"encoding/json"
+	"regexp"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -357,4 +358,63 @@ func (db *InMemoryDatabase) FindPackageCandidate(p Package) (Package, error) {
 
 	return required, err
 
+}
+
+func (db *InMemoryDatabase) FindPackageLabel(labelKey string) ([]Package, error) {
+	var ans []Package
+
+	for _, k := range db.GetPackages() {
+		pack, err := db.GetPackage(k)
+		if err != nil {
+			return ans, err
+		}
+		if pack.HasLabel(labelKey) {
+			ans = append(ans, pack)
+		}
+	}
+
+	return ans, nil
+}
+
+func (db *InMemoryDatabase) FindPackageLabelMatch(pattern string) ([]Package, error) {
+	var ans []Package
+
+	re := regexp.MustCompile(pattern)
+	if re == nil {
+		return nil, errors.New("Invalid regex " + pattern + "!")
+	}
+
+	for _, k := range db.GetPackages() {
+		pack, err := db.GetPackage(k)
+		if err != nil {
+			return ans, err
+		}
+		if pack.MatchLabel(re) {
+			ans = append(ans, pack)
+		}
+	}
+
+	return ans, nil
+}
+
+func (db *InMemoryDatabase) FindPackageMatch(pattern string) ([]Package, error) {
+	var ans []Package
+
+	re := regexp.MustCompile(pattern)
+	if re == nil {
+		return nil, errors.New("Invalid regex " + pattern + "!")
+	}
+
+	for _, k := range db.GetPackages() {
+		pack, err := db.GetPackage(k)
+		if err != nil {
+			return ans, err
+		}
+
+		if re.MatchString(pack.GetCategory() + pack.GetName()) {
+			ans = append(ans, pack)
+		}
+	}
+
+	return ans, nil
 }

--- a/pkg/package/package_test.go
+++ b/pkg/package/package_test.go
@@ -16,6 +16,8 @@
 package pkg_test
 
 import (
+	"regexp"
+
 	. "github.com/mudler/luet/pkg/package"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -58,6 +60,34 @@ var _ = Describe("Package", func() {
 			Expect(len(lst)).To(Equal(2))
 			p := Best(lst)
 			Expect(p).To(Equal(a11))
+		})
+	})
+
+	Context("Find label on packages", func() {
+		a := NewPackage("A", ">=1.0", []*DefaultPackage{}, []*DefaultPackage{})
+		a.AddLabel("project1", "test1")
+		a.AddLabel("label2", "value1")
+		b := NewPackage("B", "1.0", []*DefaultPackage{}, []*DefaultPackage{})
+		b.AddLabel("project2", "test2")
+		b.AddLabel("label2", "value1")
+		It("Expands correctly", func() {
+			var err error
+			definitions := NewInMemoryDatabase(false)
+			for _, p := range []Package{a, b} {
+				_, err = definitions.CreatePackage(p)
+				Expect(err).ToNot(HaveOccurred())
+			}
+			re := regexp.MustCompile("project[0-9][=].*")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(re).ToNot(BeNil())
+			Expect(a.HasLabel("label2")).To(Equal(true))
+			Expect(a.HasLabel("label3")).To(Equal(false))
+			Expect(a.HasLabel("project1")).To(Equal(true))
+			Expect(b.HasLabel("project2")).To(Equal(true))
+			Expect(b.HasLabel("label2")).To(Equal(true))
+			Expect(b.MatchLabel(re)).To(Equal(true))
+			Expect(a.MatchLabel(re)).To(Equal(true))
+
 		})
 	})
 

--- a/pkg/tree/tree_test.go
+++ b/pkg/tree/tree_test.go
@@ -152,4 +152,21 @@ var _ = Describe("Tree", func() {
 		})
 	})
 
+	Context("Simple tree with labels", func() {
+		It("Read tree with labels", func() {
+			db := pkg.NewInMemoryDatabase(false)
+			generalRecipe := NewCompilerRecipe(db)
+
+			err := generalRecipe.Load("../../tests/fixtures/labels")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(generalRecipe.GetDatabase().World())).To(Equal(1))
+			pack, err := generalRecipe.GetDatabase().FindPackage(&pkg.DefaultPackage{Name: "pkgA", Category: "test", Version: "0.1"})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(pack.HasLabel("label1")).To(Equal(true))
+			Expect(pack.HasLabel("label3")).To(Equal(false))
+		})
+	})
+
 })

--- a/tests/fixtures/labels/pkgA/0.1/build.yaml
+++ b/tests/fixtures/labels/pkgA/0.1/build.yaml
@@ -1,0 +1,3 @@
+image: "alpine"
+steps:
+  - echo "test" > /file1

--- a/tests/fixtures/labels/pkgA/0.1/definition.yaml
+++ b/tests/fixtures/labels/pkgA/0.1/definition.yaml
@@ -1,0 +1,6 @@
+category: "test"
+name: "pkgA"
+version: "0.1"
+labels:
+  label1: "value1"
+  label2: "value2"


### PR DESCRIPTION
* cmd/search: Add support for search of the packages
  with a specific label.

* review Search method of Repositories for permit
  different search modes.

* labels are k/v attributes and could be matched
  through label key (with HasLabel method) or through
  regex that use "$key" + "=" + "$value"