### PR TITLE
Review configuration file parsing logic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -159,17 +159,13 @@ func init() {
 	pflags.StringP("logfile", "l", config.LuetCfg.GetLogging().Path,
 		"Logfile path. Empty value disable log to file.")
 
-	sameOwner := false
-	u, err := user.Current()
-	// os/user doesn't work in from scratch environments
+	// os/user doesn't work in from scratch environments.
+	// Check if i can retrieve user informations.
+	_, err := user.Current()
 	if err != nil {
 		Warning("failed to retrieve user identity:", err.Error())
-		sameOwner = true
 	}
-	if u != nil && u.Uid == "0" {
-		sameOwner = true
-	}
-	pflags.Bool("same-owner", sameOwner, "Maintain same owner on uncompress.")
+	pflags.Bool("same-owner", config.LuetCfg.GetGeneral().SameOwner, "Maintain same owner on uncompress.")
 	pflags.Int("concurrency", runtime.NumCPU(), "Concurrency")
 
 	config.LuetCfg.Viper.BindPFlag("logging.color", pflags.Lookup("color"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -231,7 +231,7 @@ func GenDefault(viper *v.Viper) {
 
 	u, err := user.Current()
 	// os/user doesn't work in from scratch environments
-	if err != nil || u.Uid == "0" {
+	if err != nil || (u != nil && u.Uid == "0") {
 		viper.SetDefault("general.same_owner", true)
 	} else {
 		viper.SetDefault("general.same_owner", false)

--- a/pkg/helpers/sys.go
+++ b/pkg/helpers/sys.go
@@ -16,7 +16,9 @@
 package helpers
 
 import (
+	"os"
 	"os/exec"
+	"os/user"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -29,4 +31,18 @@ func Exec(cmd string, args []string, env []string) error {
 		return errors.Wrap(err, "Could not find binary in path: "+cmd)
 	}
 	return syscall.Exec(path, args, env)
+}
+
+func GetHomeDir() (ans string) {
+	// os/user doesn't work in from scratch environments
+	u, err := user.Current()
+	if err == nil {
+		ans = u.HomeDir
+	} else {
+		ans = ""
+	}
+	if os.Getenv("HOME") != "" {
+		ans = os.Getenv("HOME")
+	}
+	return ans
 }

--- a/tests/integration/09_docker.sh
+++ b/tests/integration/09_docker.sh
@@ -61,7 +61,7 @@ testInstall() {
     docker rm luet-runtime-test || true
     docker run --name luet-runtime-test \
        -ti -v /tmp:/tmp \
-       -v $tmpdir/luet.yaml:/etc/luet/.luet.yaml:ro \
+       -v $tmpdir/luet.yaml:/etc/luet/luet.yaml:ro \
        luet:test install seed/alpine
     installst=$?
     assertEquals 'install test successfully' "0" "$installst"


### PR DESCRIPTION
Luet support now these priorities on read configuration file:
- command line option (if available)
- $PWD/.luet.yaml
- $HOME/.luet.yaml
- /etc/luet/luet.yaml