### PR TITLE
Respect rootfs path for configs and url

### DIFF
--- a/contrib/config/luet.yaml
+++ b/contrib/config/luet.yaml
@@ -69,6 +69,7 @@
 #   Default $TMPDIR/tmpluet
 #   tmpdir_base: "/tmp/tmpluet"
 #
+#
 # ---------------------------------------------
 # Repositories configurations directories.
 # ---------------------------------------------
@@ -92,6 +93,11 @@
 # config protect confdir and packages
 # annotation.
 # config_protect_skip: false
+#
+# The paths used for load repositories and config
+# protects are based on host rootfs.
+# If set to false rootfs path is used as prefix.
+# config_from_host: true
 #
 # System repositories
 # ---------------------------------------------

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,7 +97,7 @@ type LuetSystemConfig struct {
 	TmpDirBase     string `yaml:"tmpdir_base" mapstructure:"tmpdir_base"`
 }
 
-func (sc LuetSystemConfig) GetRepoDatabaseDirPath(name string) string {
+func (sc *LuetSystemConfig) GetRepoDatabaseDirPath(name string) string {
 	dbpath := filepath.Join(sc.Rootfs, sc.DatabasePath)
 	dbpath = filepath.Join(dbpath, "repos/"+name)
 	err := os.MkdirAll(dbpath, os.ModePerm)
@@ -107,7 +107,7 @@ func (sc LuetSystemConfig) GetRepoDatabaseDirPath(name string) string {
 	return dbpath
 }
 
-func (sc LuetSystemConfig) GetSystemRepoDatabaseDirPath() string {
+func (sc *LuetSystemConfig) GetSystemRepoDatabaseDirPath() string {
 	dbpath := filepath.Join(sc.Rootfs,
 		sc.DatabasePath)
 	err := os.MkdirAll(dbpath, os.ModePerm)
@@ -117,7 +117,7 @@ func (sc LuetSystemConfig) GetSystemRepoDatabaseDirPath() string {
 	return dbpath
 }
 
-func (sc LuetSystemConfig) GetSystemPkgsCacheDirPath() (ans string) {
+func (sc *LuetSystemConfig) GetSystemPkgsCacheDirPath() (ans string) {
 	var cachepath string
 	if sc.PkgsCachePath != "" {
 		cachepath = sc.PkgsCachePath
@@ -133,6 +133,10 @@ func (sc LuetSystemConfig) GetSystemPkgsCacheDirPath() (ans string) {
 	}
 
 	return
+}
+
+func (sc *LuetSystemConfig) GetRootFsAbs() (string, error) {
+	return filepath.Abs(sc.Rootfs)
 }
 
 type LuetRepository struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -208,6 +208,7 @@ type LuetConfig struct {
 	RepositoriesConfDir  []string         `mapstructure:"repos_confdir"`
 	ConfigProtectConfDir []string         `mapstructure:"config_protect_confdir"`
 	ConfigProtectSkip    bool             `mapstructure:"config_protect_skip"`
+	ConfigFromHost       bool             `mapstructure:"config_from_host"`
 	CacheRepositories    []LuetRepository `mapstructure:"repetitors"`
 	SystemRepositories   []LuetRepository `mapstructure:"repositories"`
 
@@ -255,6 +256,8 @@ func GenDefault(viper *v.Viper) {
 	viper.SetDefault("repos_confdir", []string{"/etc/luet/repos.conf.d"})
 	viper.SetDefault("config_protect_confdir", []string{"/etc/luet/config.protect.d"})
 	viper.SetDefault("config_protect_skip", false)
+	// TODO: Set default to false when we are ready for migration.
+	viper.SetDefault("config_from_host", true)
 	viper.SetDefault("cache_repositories", []string{})
 	viper.SetDefault("system_repositories", []string{})
 

--- a/pkg/installer/client/local.go
+++ b/pkg/installer/client/local.go
@@ -83,8 +83,20 @@ func (c *LocalClient) DownloadFile(name string) (string, error) {
 	var err error
 	var file *os.File = nil
 
+	rootfs := ""
+
+	if !config.LuetCfg.ConfigFromHost {
+		rootfs, err = config.LuetCfg.GetSystem().GetRootFsAbs()
+		if err != nil {
+			return "", err
+		}
+	}
+
 	ok := false
 	for _, uri := range c.RepoData.Urls {
+
+		uri = filepath.Join(rootfs, uri)
+
 		Info("Downloading file", name, "from", uri)
 		file, err = config.LuetCfg.GetSystem().TempFile("localclient")
 		if err != nil {

--- a/pkg/installer/client/local.go
+++ b/pkg/installer/client/local.go
@@ -38,8 +38,16 @@ func NewLocalClient(r RepoData) *LocalClient {
 func (c *LocalClient) DownloadArtifact(artifact compiler.Artifact) (compiler.Artifact, error) {
 	var err error
 
+	rootfs := ""
 	artifactName := path.Base(artifact.GetPath())
 	cacheFile := filepath.Join(config.LuetCfg.GetSystem().GetSystemPkgsCacheDirPath(), artifactName)
+
+	if !config.LuetCfg.ConfigFromHost {
+		rootfs, err = config.LuetCfg.GetSystem().GetRootFsAbs()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	// Check if file is already in cache
 	if helpers.Exists(cacheFile) {
@@ -47,6 +55,9 @@ func (c *LocalClient) DownloadArtifact(artifact compiler.Artifact) (compiler.Art
 	} else {
 		ok := false
 		for _, uri := range c.RepoData.Urls {
+
+			uri = filepath.Join(rootfs, uri)
+
 			Info("Downloading artifact", artifactName, "from", uri)
 
 			//defer os.Remove(file.Name())

--- a/pkg/installer/config_protect.go
+++ b/pkg/installer/config_protect.go
@@ -19,6 +19,7 @@ package installer
 import (
 	"io/ioutil"
 	"path"
+	"path/filepath"
 	"regexp"
 
 	"github.com/ghodss/yaml"
@@ -30,7 +31,15 @@ import (
 func LoadConfigProtectConfs(c *LuetConfig) error {
 	var regexConfs = regexp.MustCompile(`.yml$`)
 
+	// Respect the rootfs param on read repositories
+	rootfs, err := c.GetSystem().GetRootFsAbs()
+	if err != nil {
+		return err
+	}
+
 	for _, cdir := range c.ConfigProtectConfDir {
+		cdir = filepath.Join(rootfs, cdir)
+
 		Debug("Parsing Config Protect Directory", cdir, "...")
 
 		files, err := ioutil.ReadDir(cdir)

--- a/pkg/installer/config_protect.go
+++ b/pkg/installer/config_protect.go
@@ -30,11 +30,16 @@ import (
 
 func LoadConfigProtectConfs(c *LuetConfig) error {
 	var regexConfs = regexp.MustCompile(`.yml$`)
+	var err error
+
+	rootfs := ""
 
 	// Respect the rootfs param on read repositories
-	rootfs, err := c.GetSystem().GetRootFsAbs()
-	if err != nil {
-		return err
+	if !c.ConfigFromHost {
+		rootfs, err = c.GetSystem().GetRootFsAbs()
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, cdir := range c.ConfigProtectConfDir {

--- a/pkg/repository/loader.go
+++ b/pkg/repository/loader.go
@@ -30,11 +30,15 @@ import (
 
 func LoadRepositories(c *LuetConfig) error {
 	var regexRepo = regexp.MustCompile(`.yml$|.yaml$`)
+	var err error
+	rootfs := ""
 
 	// Respect the rootfs param on read repositories
-	rootfs, err := c.GetSystem().GetRootFsAbs()
-	if err != nil {
-		return err
+	if !c.ConfigFromHost {
+		rootfs, err = c.GetSystem().GetRootFsAbs()
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, rdir := range c.RepositoriesConfDir {

--- a/pkg/repository/loader.go
+++ b/pkg/repository/loader.go
@@ -19,6 +19,7 @@ package repository
 import (
 	"io/ioutil"
 	"path"
+	"path/filepath"
 	"regexp"
 
 	"github.com/ghodss/yaml"
@@ -30,7 +31,16 @@ import (
 func LoadRepositories(c *LuetConfig) error {
 	var regexRepo = regexp.MustCompile(`.yml$|.yaml$`)
 
+	// Respect the rootfs param on read repositories
+	rootfs, err := c.GetSystem().GetRootFsAbs()
+	if err != nil {
+		return err
+	}
+
 	for _, rdir := range c.RepositoriesConfDir {
+
+		rdir = filepath.Join(rootfs, rdir)
+
 		Debug("Parsing Repository Directory", rdir, "...")
 
 		files, err := ioutil.ReadDir(rdir)

--- a/tests/integration/01_simple.sh
+++ b/tests/integration/01_simple.sh
@@ -43,6 +43,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/01_simple_gzip.sh
+++ b/tests/integration/01_simple_gzip.sh
@@ -48,6 +48,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/01_simple_meta_gzip.sh
+++ b/tests/integration/01_simple_meta_gzip.sh
@@ -51,6 +51,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/02_create_repo_from_config.sh
+++ b/tests/integration/02_create_repo_from_config.sh
@@ -28,6 +28,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/03_qlearning.sh
+++ b/tests/integration/03_qlearning.sh
@@ -43,6 +43,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/04_retrieve.sh
+++ b/tests/integration/04_retrieve.sh
@@ -43,6 +43,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/05_upgrade.sh
+++ b/tests/integration/05_upgrade.sh
@@ -71,6 +71,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/06_search.sh
+++ b/tests/integration/06_search.sh
@@ -70,6 +70,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/07_finalizer.sh
+++ b/tests/integration/07_finalizer.sh
@@ -42,6 +42,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/07_finalizer_custom.sh
+++ b/tests/integration/07_finalizer_custom.sh
@@ -42,6 +42,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/08_versioning.sh
+++ b/tests/integration/08_versioning.sh
@@ -50,6 +50,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/09_docker.sh
+++ b/tests/integration/09_docker.sh
@@ -42,6 +42,7 @@ system:
   rootfs: /
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/10_tmpdir_cleanup.sh
+++ b/tests/integration/10_tmpdir_cleanup.sh
@@ -44,6 +44,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/11_upgrade_universe.sh
+++ b/tests/integration/11_upgrade_universe.sh
@@ -71,6 +71,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/12_config_protect.sh
+++ b/tests/integration/12_config_protect.sh
@@ -11,18 +11,19 @@ oneTimeTearDown() {
 }
 
 testBuild() {
-    mkdir $tmpdir/testbuild
-    luet build --tree "$ROOT_DIR/tests/fixtures/config_protect" --destination $tmpdir/testbuild --compression gzip test/a
+    mkdir $tmpdir/testrootfs/testbuild -p
+    luet build --tree "$ROOT_DIR/tests/fixtures/config_protect" \
+      --destination $tmpdir/testrootfs/testbuild --compression gzip test/a
     buildst=$?
     assertEquals 'builds successfully' "$buildst" "0"
-    assertTrue 'create package' "[ -e '$tmpdir/testbuild/a-test-1.0.package.tar.gz' ]"
+    assertTrue 'create package' "[ -e '$tmpdir/testrootfs/testbuild/a-test-1.0.package.tar.gz' ]"
 }
 
 testRepo() {
     assertTrue 'no repository' "[ ! -e '$tmpdir/testbuild/repository.yaml' ]"
     luet create-repo --tree "$ROOT_DIR/tests/fixtures/config_protect" \
-    --output $tmpdir/testbuild \
-    --packages $tmpdir/testbuild \
+    --output $tmpdir/testrootfs/testbuild \
+    --packages $tmpdir/testrootfs/testbuild \
     --name "test" \
     --descr "Test Repo" \
     --urls $tmpdir/testrootfs \
@@ -30,11 +31,10 @@ testRepo() {
 
     createst=$?
     assertEquals 'create repo successfully' "$createst" "0"
-    assertTrue 'create repository' "[ -e '$tmpdir/testbuild/repository.yaml' ]"
+    assertTrue 'create repository' "[ -e '$tmpdir/testrootfs/testbuild/repository.yaml' ]"
 }
 
 testConfig() {
-    mkdir $tmpdir/testrootfs
 
     mkdir $tmpdir/testrootfs/etc/luet/config.protect.d -p
 
@@ -59,7 +59,7 @@ repositories:
      type: "disk"
      enable: true
      urls:
-       - "$tmpdir/testbuild"
+       - "/testbuild"
 EOF
     luet config --config $tmpdir/luet.yaml
     res=$?

--- a/tests/integration/12_config_protect.sh
+++ b/tests/integration/12_config_protect.sh
@@ -36,9 +36,9 @@ testRepo() {
 testConfig() {
     mkdir $tmpdir/testrootfs
 
-    mkdir $tmpdir/config.protect.d
+    mkdir $tmpdir/testrootfs/etc/luet/config.protect.d -p
 
-    cat <<EOF > $tmpdir/config.protect.d/conf1.yml
+    cat <<EOF > $tmpdir/testrootfs/etc/luet/config.protect.d/conf1.yml
 name: "protect1"
 dirs:
 - /etc/
@@ -52,7 +52,8 @@ system:
   database_path: "/"
   database_engine: "boltdb"
 config_protect_confdir:
-    - $tmpdir/config.protect.d
+    - /etc/luet/config.protect.d
+config_from_host: false
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/13_config_protect_annotation.sh
+++ b/tests/integration/13_config_protect_annotation.sh
@@ -54,6 +54,7 @@ system:
   database_engine: "boltdb"
 config_protect_confdir:
     - $tmpdir/config.protect.d
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/14_upgrade_revision.sh
+++ b/tests/integration/14_upgrade_revision.sh
@@ -61,6 +61,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/15_symlinks.sh
+++ b/tests/integration/15_symlinks.sh
@@ -42,6 +42,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/16_caps.sh
+++ b/tests/integration/16_caps.sh
@@ -42,6 +42,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"

--- a/tests/integration/17_config_protect_skip.sh
+++ b/tests/integration/17_config_protect_skip.sh
@@ -52,6 +52,7 @@ system:
   database_path: "/"
   database_engine: "boltdb"
 config_protect_skip: true
+config_from_host: true
 config_protect_confdir:
     - $tmpdir/config.protect.d
 repositories:

--- a/tests/integration/18_database.sh
+++ b/tests/integration/18_database.sh
@@ -43,6 +43,7 @@ system:
   rootfs: $tmpdir/testrootfs
   database_path: "/"
   database_engine: "boltdb"
+config_from_host: true
 repositories:
    - name: "main"
      type: "disk"


### PR DESCRIPTION
* integrate rootfs prefix for configs and repos URLs (https://github.com/mudler/luet/issues/141)
* add config_from_host option (https://github.com/mudler/luet/issues/142)
* temporary I maintained the previous logic with `config_from_host` to true. We will move soon to value false by default.