### PR TITLE
cmd/database/create: Avoid creation of the same package multiple times

### DIFF
--- a/cmd/database/create.go
+++ b/cmd/database/create.go
@@ -74,6 +74,12 @@ For reference, inspect a "metadata.yaml" file generated while running "luet buil
 
 				files := art.Files
 
+				// Check if the package is already present
+				if p, err := systemDB.FindPackage(art.CompileSpec.GetPackage()); err == nil && p.GetName() != "" {
+					Fatal("Package", art.CompileSpec.GetPackage().HumanReadableString(),
+						" already present.")
+				}
+
 				if _, err := systemDB.CreatePackage(art.CompileSpec.GetPackage()); err != nil {
 					Fatal("Failed to create ", a, ": ", err.Error())
 				}


### PR DESCRIPTION
This is what happens now if it's already present:
```shell
$> luet database create Digest-HMAC-dev-perl-1.30.0-r1.metadata.yaml 
 Package dev-perl/Digest-HMAC-1.30.0-r1  already present.
```