### PR TITLE
Change gox for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,20 @@
+builds:
+  -
+    binary: release/luet-{{ .Tag }}-{{ .Os }}-{{ .Arch }}
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -X "github.com/mudler/luet/cmd.BuildTime={{ time "2006-01-02 15:04:05 MST" }}"
+      - -X "github.com/mudler/luet/cmd.BuildCommit={{ .FullCommit }}"
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - 386
+    goarm:
+      - 6
+      - 7
+archives:
+  - format: binary # this removes the tar of the archives, leaving the binaries alone

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ deps:
 	go env
 	# Installing dependencies...
 	GO111MODULE=off go get golang.org/x/lint/golint
-	GO111MODULE=off go get github.com/mitchellh/gox
+	GO111MODULE=off go get github.com/goreleaser/goreleaser
 	GO111MODULE=off go get golang.org/x/tools/cmd/cover
 	GO111MODULE=off go get github.com/onsi/ginkgo/ginkgo
 	GO111MODULE=off go get github.com/onsi/gomega/...
@@ -89,10 +89,10 @@ test-docker:
 				bash -c "make test"
 
 multiarch-build:
-	CGO_ENABLED=0 gox $(BUILD_PLATFORMS) -ldflags '$(LDFLAGS)' -output="release/$(NAME)-$(VERSION)-{{.OS}}-{{.Arch}}"
+	goreleaser build --snapshot --rm-dist
 
 multiarch-build-small:
 	@$(MAKE) LDFLAGS+="-s -w" multiarch-build
-	for file in $(ROOT_DIR)/release/* ; do \
+	for file in $(ROOT_DIR)/dist/**/release/* ; do \
 		upx --brute -1 $${file} ; \
 	done


### PR DESCRIPTION
gox hasnt had any change in several years (!) plus its still broken in
some places.

This patch changes gox for goreleaser which has a clean config in plain
yaml, multitude of configuration opetions and can even be plugged into
github actions to make automated releases and checksums, archives,
etc...

Signed-off-by: Itxaka <igarcia@suse.com>