### PR TITLE
compiler: Avoid generation of delta if there are only prelude steps

### DIFF
--- a/pkg/compiler/types/spec/spec.go
+++ b/pkg/compiler/types/spec/spec.go
@@ -242,7 +242,7 @@ func (cs *LuetCompilationSpec) SetSeedImage(s string) {
 }
 
 func (cs *LuetCompilationSpec) EmptyPackage() bool {
-	return len(cs.BuildSteps()) == 0 && len(cs.GetPreBuildSteps()) == 0 && !cs.UnpackedPackage()
+	return len(cs.BuildSteps()) == 0 && !cs.UnpackedPackage()
 }
 
 func (cs *LuetCompilationSpec) UnpackedPackage() bool {


### PR DESCRIPTION
Create a build.yaml with only prelude steps will never contain delta from the build layer.