### PR TITLE
installer: Take into consideration provides names

### DIFF
--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -551,6 +551,11 @@ func (l *LuetInstaller) Install(cp pkg.Packages, s *System) error {
 				if m.Package.GetName() == p.GetName() {
 					found = true
 				}
+				for _, pack := range m.Package.GetProvides() {
+					if pack.GetName() == p.GetName() {
+						found = true
+					}
+				}
 			}
 
 			if !found {


### PR DESCRIPTION
When installing a package that has a provides values, the installer only
checks the original package against the resolved package. This leads to
the requires keyword not working as expected as the solved final package
is never gonna match the name of the old/superseeded package.

This patch checks the asked-to-install package name against the list of
names that the matched name provides.

Signed-off-by: Itxaka <igarcia@suse.com>