### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/content/en/docs/Getting started/_index.md
+++ b/docs/content/en/docs/Getting started/_index.md
@@ -9,7 +9,7 @@ description: >
 
 ## Prerequisites
 
-No dependencies. For building packages [see the Build Packages section](/docs/docs/concepts/overview/build_packages/)
+No dependencies. For building packages [see the Build Packages section](/docs/concepts/overview/build_packages/)
 
 ## Get Luet  
 


### PR DESCRIPTION
Incorrect link to the Build packages section in the documentation . 

 