### PR TITLE
:bug: Bail out when no packages are found with default solvers

### DIFF
--- a/pkg/api/core/image/delta_test.go
+++ b/pkg/api/core/image/delta_test.go
@@ -53,17 +53,18 @@ var _ = Describe("Delta", func() {
 			var img, img2 v1.Image
 			var err error
 
-			ref, _ = name.ParseReference("alpine")
-			ref2, _ = name.ParseReference("golang:alpine")
-			img, _ = daemon.Image(ref)
-			img2, _ = daemon.Image(ref2)
-
 			BeforeEach(func() {
 				ctx = context.NewContext()
+				ctx.Config.General.Debug = true
 
 				tmpfile, err = ioutil.TempFile("", "delta")
 				Expect(err).ToNot(HaveOccurred())
 				defer os.RemoveAll(tmpfile.Name()) // clean up
+
+				ref, _ = name.ParseReference("alpine")
+				ref2, _ = name.ParseReference("golang:1.16-alpine3.14")
+				img, _ = daemon.Image(ref)
+				img2, _ = daemon.Image(ref2)
 			})
 
 			It("Extract all deltas", func() {

--- a/pkg/api/core/image/mutator_suite_test.go
+++ b/pkg/api/core/image/mutator_suite_test.go
@@ -29,6 +29,6 @@ func TestImageApi(t *testing.T) {
 	b := backend.NewSimpleDockerBackend(context.NewContext())
 	b.DownloadImage(backend.Options{ImageName: "alpine"})
 	b.DownloadImage(backend.Options{ImageName: "golang:alpine"})
-
+	b.DownloadImage(backend.Options{ImageName: "golang:1.16-alpine3.14"})
 	RunSpecs(t, "Image API Suite")
 }

--- a/pkg/api/core/types/package.go
+++ b/pkg/api/core/types/package.go
@@ -291,6 +291,11 @@ func (p *Package) String() string {
 	return fmt.Sprintf("%s", string(b))
 }
 
+// HasVersionDefined returns true when a specific version of a package is implied
+func (p *Package) HasVersionDefined() bool {
+	return p.Version != ">=0"
+}
+
 // GetFingerPrint returns a UUID of the package.
 // FIXME: this needs to be unique, now just name is generalized
 func (p *Package) GetFingerPrint() string {

--- a/pkg/solver/solver.go
+++ b/pkg/solver/solver.go
@@ -40,6 +40,13 @@ type Solver struct {
 	Resolver types.PackageResolver
 }
 
+// IsRelaxedResolver returns true wether a solver might
+// take action on user side, by removing some installation constraints
+// or taking automated actions (e.g. qlearning)
+func IsRelaxedResolver(t types.LuetSolverOptions) bool {
+	return t.Type == QLearningResolverType
+}
+
 // NewSolver accepts as argument two lists of packages, the first is the initial set,
 // the second represent all the known packages.
 func NewSolver(t types.SolverOptions, installed types.PackageDatabase, definitiondb types.PackageDatabase, solverdb types.PackageDatabase) types.PackageSolver {

--- a/tests/integration/01_simple.sh
+++ b/tests/integration/01_simple.sh
@@ -57,11 +57,39 @@ EOF
 }
 
 testInstall() {
+    luet install -y --config $tmpdir/luet.yaml test/foobar
+    installst=$?
+    assertEquals 'install test fails' "$installst" "2"
+
+    luet install -y --config $tmpdir/luet.yaml test/foobar test/c
+    installst=$?
+    assertEquals 'install test fails' "$installst" "2"
+
+    luet install -y --config $tmpdir/luet.yaml test/foobar@1.0
+    installst=$?
+    assertEquals 'install test fails' "$installst" "2"
+
+    luet install -y --config $tmpdir/luet.yaml test/foobar@1.0 test/c@1.0
+    installst=$?
+    assertEquals 'install test fails' "$installst" "2"
+
+    luet install -y --config $tmpdir/luet.yaml test/foobar@1.0 test/c
+    installst=$?
+    assertEquals 'install test fails' "$installst" "2"
+
     luet install -y --config $tmpdir/luet.yaml test/c
-    #luet install -y --config $tmpdir/luet.yaml test/c@1.0 > /dev/null
     installst=$?
     assertEquals 'install test successfully' "$installst" "0"
     assertTrue 'package installed' "[ -e '$tmpdir/testrootfs/c' ]"
+
+    luet install -y --config $tmpdir/luet.yaml test/foobar test/c
+    installst=$?
+    assertEquals 'install test fails' "$installst" "2"
+
+    # Already installed
+    luet install -y --config $tmpdir/luet.yaml test/c@1.0
+    installst=$?
+    assertEquals 'install test fails' "$installst" "0"
 }
 
 testReInstall() {


### PR DESCRIPTION
Checking packages is more tricky when a resolver is set. Resolvers
are capable of mutating the user request and remove part of the
constraints in order to resolve a specific solution.

This had the countereffect on a normal solver to not detect correctly
packages when missing from the wanted set and not proposed during
installation.

This should fix all the cases above taking into consideration of
resolvers and adding specific test-cases for it.