### PR TITLE
Print all not-found packages

### DIFF
--- a/pkg/api/core/image/extract_test.go
+++ b/pkg/api/core/image/extract_test.go
@@ -23,11 +23,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	daemon "github.com/google/go-containerregistry/pkg/v1/daemon"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/mudler/luet/pkg/api/core/context"
 	. "github.com/mudler/luet/pkg/api/core/image"
 	"github.com/mudler/luet/pkg/helpers/file"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Extract", func() {
@@ -61,10 +62,10 @@ var _ = Describe("Extract", func() {
 					ExtractFiles(ctx, "", []string{}, []string{}),
 				)
 				Expect(err).ToNot(HaveOccurred())
-				defer os.RemoveAll(tmpdir) // clean up
+				// defer os.RemoveAll(tmpdir) // clean up
 
-				Expect(file.Exists(filepath.Join(tmpdir, "usr", "bin"))).To(BeTrue())
-				Expect(file.Exists(filepath.Join(tmpdir, "bin", "sh"))).To(BeTrue())
+				Expect(filepath.Join(tmpdir, "usr", "bin")).To(BeADirectory())
+				Expect(filepath.Join(tmpdir, "bin", "busybox")).To(BeARegularFile())
 			})
 
 			It("Extract specific dir", func() {
@@ -75,9 +76,9 @@ var _ = Describe("Extract", func() {
 				)
 				Expect(err).ToNot(HaveOccurred())
 				defer os.RemoveAll(tmpdir) // clean up
-				Expect(file.Exists(filepath.Join(tmpdir, "usr", "sbin"))).To(BeTrue())
-				Expect(file.Exists(filepath.Join(tmpdir, "usr", "bin"))).To(BeTrue())
-				Expect(file.Exists(filepath.Join(tmpdir, "bin", "sh"))).To(BeFalse())
+				Expect(filepath.Join(tmpdir, "usr", "sbin")).To(BeADirectory())
+				Expect(filepath.Join(tmpdir, "usr", "bin")).To(BeADirectory())
+				Expect(filepath.Join(tmpdir, "bin", "busybox")).ToNot(BeARegularFile())
 			})
 
 			It("Extract a dir with includes/excludes", func() {
@@ -103,8 +104,8 @@ var _ = Describe("Extract", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer os.RemoveAll(tmpdir) // clean up
 
-				Expect(file.Exists(filepath.Join(tmpdir, "usr", "bin"))).To(BeTrue())
-				Expect(file.Exists(filepath.Join(tmpdir, "bin", "sh"))).To(BeFalse())
+				Expect(filepath.Join(tmpdir, "usr", "bin")).To(BeADirectory())
+				Expect(filepath.Join(tmpdir, "bin", "busybox")).ToNot(BeARegularFile())
 			})
 		})
 	})

--- a/pkg/api/core/types/artifact/artifact_test.go
+++ b/pkg/api/core/types/artifact/artifact_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/mudler/luet/pkg/api/core/types"
+
 	"github.com/mudler/luet/pkg/compiler"
 
 	"github.com/mudler/luet/pkg/api/core/context"
@@ -91,7 +92,7 @@ ENV PACKAGE_CATEGORY=app-admin`))
 			}
 			Expect(b.BuildImage(opts)).ToNot(HaveOccurred())
 			Expect(b.ExportImage(opts)).ToNot(HaveOccurred())
-			Expect(fileHelper.Exists(filepath.Join(tmpdir2, "output1.tar"))).To(BeTrue())
+			Expect(filepath.Join(tmpdir2, "output1.tar")).To(BeARegularFile())
 			Expect(b.BuildImage(opts)).ToNot(HaveOccurred())
 
 			err = lspec.WriteStepImageDefinition(lspec.Image, filepath.Join(tmpdir, "LuetDockerfile"))


### PR DESCRIPTION
When trying to install several packages that are not found luet will now
print all packages that are not found, instead of only first one.

```sh
$ LUET_NOLOCK=true luet install asd qwe 
...
Error: packages 'asd', 'qwe' not found
```